### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "vigour-ua": "^2.0.0",
     "brisky-props": "^1.2.3",
     "brisky-core": "^1.6.2",
-    "brisky-events": "^1.3.2",
-    "babel-preset-es2015": "^6.6.0",
-    "babelify": "^7.3.0"
+    "brisky-events": "^1.3.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 2 of the runtime dependencies is installed, however, they are not used during the test runtime. We removed these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?